### PR TITLE
Build to pass CI

### DIFF
--- a/lib/Main.js
+++ b/lib/Main.js
@@ -55,7 +55,7 @@ function createAction() {
     const globber = new ArtifactGlobber_1.FileArtifactGlobber();
     const inputs = new Inputs_1.CoreInputs(globber, context);
     const releases = new Releases_1.GithubReleases(inputs, git);
-    const uploader = new ArtifactUploader_1.GithubArtifactUploader(releases, inputs.replacesArtifacts);
+    const uploader = new ArtifactUploader_1.GithubArtifactUploader(releases, inputs.replacesArtifacts, inputs.artifactErrorsFailBuild);
     return new Action_1.Action(inputs, releases, uploader);
 }
 run();


### PR DESCRIPTION
A proper build of lib/Main.js that'll fix the CI error in https://github.com/gdcorp-action-public-forks/ncipollo-release-action/runs/2170458091

Replaces #2 

## QA
1. `git checkout build-js-to-fix-ci`
2. `yarn && yarn build`
- [x] js build is already committed, so there should be no changes